### PR TITLE
release lock in other process

### DIFF
--- a/redislock.go
+++ b/redislock.go
@@ -184,6 +184,18 @@ func (l *Lock) Release() error {
 	return nil
 }
 
+// If you want to release lock in other project, you may use this func
+func (l *Lock) GetKeyAndValue() (string, string) {
+	return l.key, l.value
+}
+
+// short-cut for Lock.Release()
+// If you want to release lock in other project, you may use this func
+func Release(client RedisClient, key, value string) error {
+	l := &Lock{client: New(client), key: key, value: value}
+	return l.Release()
+}
+
 // --------------------------------------------------------------------
 
 // Options describe the options for the lock

--- a/redislock_test.go
+++ b/redislock_test.go
@@ -140,6 +140,14 @@ var _ = Describe("Client", func() {
 		Expect(numLocks).To(Equal(int32(1)))
 	})
 
+	It("should release use short-cut Release", func() {
+		lock, err := redislock.Obtain(redisClient, lockKey, 30*time.Second, nil)
+		Expect(err).NotTo(HaveOccurred())
+		key, value := lock.GetKeyAndValue()
+		Expect(redislock.Release(redisClient, key, value)).NotTo(HaveOccurred())
+		Expect(redislock.Release(redisClient, key, value)).To(MatchError(redislock.ErrLockNotHeld))
+	})
+
 })
 
 var _ = Describe("RetryStrategy", func() {


### PR DESCRIPTION
I want to Obtain a lock in my grpc servicer, and release it in an async task(invoke by grpc servicer).

`key` and `value` can be passed to async task. So I add `GetKeyAndValue` and short-cut `Release` func to do it.