### PR TITLE
Fix data race when using RetryStrategy

### DIFF
--- a/redislock.go
+++ b/redislock.go
@@ -266,10 +266,9 @@ func ExponentialBackoff(min, max time.Duration) RetryStrategy {
 }
 
 func (r *exponentialBackoff) NextBackoff() time.Duration {
-	atomic.AddUint32(&r.cnt, 1)
+	cnt := atomic.AddUint32(&r.cnt, 1)
 
 	ms := 2 << 25
-	cnt := atomic.LoadUint32(&r.cnt)
 	if cnt < 25 {
 		ms = 2 << cnt
 	}

--- a/redislock.go
+++ b/redislock.go
@@ -235,18 +235,18 @@ func (r linearBackoff) NextBackoff() time.Duration {
 }
 
 type limitedRetry struct {
-	s RetryStrategy
-
-	cnt, max int32
+	s   RetryStrategy
+	cnt int32
+	max int
 }
 
 // LimitRetry limits the number of retries to max attempts.
-func LimitRetry(s RetryStrategy, max int32) RetryStrategy {
+func LimitRetry(s RetryStrategy, max int) RetryStrategy {
 	return &limitedRetry{s: s, max: max}
 }
 
 func (r *limitedRetry) NextBackoff() time.Duration {
-	if atomic.LoadInt32(&r.cnt) >= r.max {
+	if atomic.LoadInt32(&r.cnt) >= int32(r.max) {
 		return 0
 	}
 	atomic.AddInt32(&r.cnt, 1)

--- a/redislock_test.go
+++ b/redislock_test.go
@@ -2,7 +2,6 @@ package redislock_test
 
 import (
 	"context"
-	"math/rand"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -127,9 +126,6 @@ var _ = Describe("Client", func() {
 				defer GinkgoRecover()
 				defer wg.Done()
 
-				wait := rand.Int63n(int64(50 * time.Millisecond))
-				time.Sleep(time.Duration(wait))
-
 				_, err := subject.Obtain(ctx, lockKey, time.Minute, nil)
 				if err == redislock.ErrNotObtained {
 					return
@@ -155,9 +151,6 @@ var _ = Describe("Client", func() {
 				defer GinkgoRecover()
 				defer wg.Done()
 
-				wait := rand.Int63n(int64(50 * time.Millisecond))
-				time.Sleep(time.Duration(wait))
-
 				_, err := subject.Obtain(ctx, lockKey, time.Minute, cacheOpts)
 				if err == redislock.ErrNotObtained {
 					return
@@ -182,9 +175,6 @@ var _ = Describe("Client", func() {
 			go func() {
 				defer GinkgoRecover()
 				defer wg.Done()
-
-				wait := rand.Int63n(int64(50 * time.Millisecond))
-				time.Sleep(time.Duration(wait))
 
 				_, err := subject.Obtain(ctx, lockKey, time.Minute, cacheOpts)
 				if err == redislock.ErrNotObtained {

--- a/redislock_test.go
+++ b/redislock_test.go
@@ -142,6 +142,61 @@ var _ = Describe("Client", func() {
 		Expect(numLocks).To(Equal(int32(1)))
 	})
 
+	It("should prevent multiple locks with linear retry (fuzzing)", func() {
+		numLocks := int32(0)
+		wg := new(sync.WaitGroup)
+		var cacheOpts = &redislock.Options{
+			RetryStrategy: redislock.LimitRetry(redislock.LinearBackoff(30*time.Millisecond), 10),
+		}
+		for i := 0; i < 1000; i++ {
+			wg.Add(1)
+
+			go func() {
+				defer GinkgoRecover()
+				defer wg.Done()
+
+				wait := rand.Int63n(int64(50 * time.Millisecond))
+				time.Sleep(time.Duration(wait))
+
+				_, err := subject.Obtain(ctx, lockKey, time.Minute, cacheOpts)
+				if err == redislock.ErrNotObtained {
+					return
+				}
+				Expect(err).NotTo(HaveOccurred())
+				atomic.AddInt32(&numLocks, 1)
+			}()
+		}
+		wg.Wait()
+		Expect(numLocks).To(Equal(int32(1)))
+	})
+
+	It("should prevent multiple locks with exponential retry (fuzzing)", func() {
+		numLocks := int32(0)
+		wg := new(sync.WaitGroup)
+		var cacheOpts = &redislock.Options{
+			RetryStrategy: redislock.LimitRetry(redislock.ExponentialBackoff(30*time.Millisecond, 5*time.Second), 10),
+		}
+		for i := 0; i < 1000; i++ {
+			wg.Add(1)
+
+			go func() {
+				defer GinkgoRecover()
+				defer wg.Done()
+
+				wait := rand.Int63n(int64(50 * time.Millisecond))
+				time.Sleep(time.Duration(wait))
+
+				_, err := subject.Obtain(ctx, lockKey, time.Minute, cacheOpts)
+				if err == redislock.ErrNotObtained {
+					return
+				}
+				Expect(err).NotTo(HaveOccurred())
+				atomic.AddInt32(&numLocks, 1)
+			}()
+		}
+		wg.Wait()
+		Expect(numLocks).To(Equal(int32(1)))
+	})
 })
 
 var _ = Describe("RetryStrategy", func() {


### PR DESCRIPTION
When using linear and exponential backoff retry strategy, there is data race when increasing the counter `cnt`.