### PR TITLE
Add support for secret key based lock reobtaining

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -6,8 +6,9 @@ import (
 	"log"
 	"time"
 
-	"github.com/bsm/redislock"
 	"github.com/go-redis/redis/v9"
+
+	"github.com/bsm/redislock"
 )
 
 func Example() {
@@ -46,6 +47,82 @@ func Example() {
 	// Extend my lock.
 	if err := lock.Refresh(ctx, 100*time.Millisecond, nil); err != nil {
 		log.Fatalln(err)
+	}
+
+	// Sleep a little longer, then check.
+	time.Sleep(100 * time.Millisecond)
+	if ttl, err := lock.TTL(ctx); err != nil {
+		log.Fatalln(err)
+	} else if ttl == 0 {
+		fmt.Println("Now, my lock has expired!")
+	}
+
+	// Output:
+	// I have a lock!
+	// Yay, I still have my lock!
+	// Now, my lock has expired!
+}
+
+func ExampleClient_Obtain_With_Secret() {
+	// Connect to redis.
+	client := redis.NewClient(&redis.Options{
+		Network: "tcp",
+		Addr:    "127.0.0.1:6379",
+	})
+	defer client.Close()
+
+	// Create a new lock client.
+	locker := redislock.New(client)
+
+	ctx := context.Background()
+
+	opts := &redislock.Options{
+		Secret: "test",
+	}
+	// Try to obtain lock.
+	lock, err := locker.Obtain(ctx, "my-key", 100*time.Millisecond, opts)
+	if err == redislock.ErrNotObtained {
+		fmt.Println("Could not obtain lock!")
+	} else if err != nil {
+		log.Fatalln(err)
+	}
+
+	// Don't forget to defer Release.
+	defer lock.Release(ctx)
+	fmt.Println("I have a lock!")
+
+	// Sleep and check the remaining TTL.
+	time.Sleep(50 * time.Millisecond)
+	if ttl, err := lock.TTL(ctx); err != nil {
+		log.Fatalln(err)
+	} else if ttl > 0 {
+		fmt.Println("Yay, I still have my lock!")
+	}
+
+	lock2, err := locker.Obtain(ctx, "my-key", 100*time.Millisecond, opts)
+	if err == redislock.ErrNotObtained {
+		fmt.Println("Could not obtain lock!")
+	} else if err != nil {
+		log.Fatalln(err)
+	}
+
+	// Sleep and check the remaining TTL.
+	time.Sleep(50 * time.Millisecond)
+	if ttl, err := lock2.TTL(ctx); err != nil {
+		log.Fatalln(err)
+	} else if ttl > 0 {
+		fmt.Println("Yay, I still have my lock!")
+	}
+
+	lock3, err := locker.Obtain(ctx, "my-key", 100*time.Millisecond, nil)
+	if err == redislock.ErrNotObtained {
+		fmt.Println("Could not obtain lock, but it's ok!")
+	} else if err != nil {
+		log.Fatalln(err)
+	}
+
+	if lock3 != nil {
+		log.Fatalln("lock3 should be nil")
 	}
 
 	// Sleep a little longer, then check.


### PR DESCRIPTION
Using this PR, you are able to obtain a lock that was already locked (e.g.: it was created by other process).

To make it possible, you have to provide the same Secret during calling the Obtain() function.