### PR TITLE
Reset backoff timer for exponential backoff

### DIFF
--- a/redislock.go
+++ b/redislock.go
@@ -82,6 +82,8 @@ func (c *Client) Obtain(ctx context.Context, key string, ttl time.Duration, opt 
 		if ticker == nil {
 			ticker = time.NewTicker(backoff)
 			defer ticker.Stop()
+		} else {
+			ticker.Reset(backoff)
 		}
 
 		select {


### PR DESCRIPTION
## Description
- With exponential backoff, the ticker is only set with the initial backoff duration. So even if the backoff duration is increased, the wait time is still the min value
- I added the `ticker.Reset` to add new backoff duration to the timer