### PR TITLE
obtain: wrap ctx error with ErrNotObtained when retry deadline hits

### DIFF
--- a/redislock.go
+++ b/redislock.go
@@ -113,7 +113,10 @@ func (c *Client) ObtainMulti(ctx context.Context, keys []string, ttl time.Durati
 
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			// Surface both errors so callers can still match on
+			// ErrNotObtained (their reason for calling Obtain) while
+			// also keeping the context error for diagnostics.
+			return nil, errors.Join(ErrNotObtained, ctx.Err())
 		case <-ticker.C:
 		}
 	}

--- a/redislock_test.go
+++ b/redislock_test.go
@@ -174,6 +174,34 @@ func TestObtain_retry_failure(t *testing.T) {
 	}
 }
 
+// When Obtain gives up because the caller's context expired, the returned
+// error should still be matchable as ErrNotObtained (so callers that only
+// care about "did we get the lock?" can keep using errors.Is(err, ErrNotObtained))
+// while also wrapping the context error for diagnostics.
+func TestObtain_ctx_deadline_joins_not_obtained(t *testing.T) {
+	lockKey := getLockKey()
+	rc := redis.NewClient(redisOpts)
+	defer teardown(t, rc, lockKey)
+
+	// hold the lock for longer than the caller's deadline so retry never wins
+	bgCtx := context.Background()
+	lock1 := quickObtain(t, rc, lockKey, time.Second)
+	defer lock1.Release(bgCtx)
+
+	ctx, cancel := context.WithTimeout(bgCtx, 30*time.Millisecond)
+	defer cancel()
+
+	_, err := Obtain(ctx, rc, lockKey, time.Hour, &Options{
+		RetryStrategy: LinearBackoff(10 * time.Millisecond),
+	})
+	if !errors.Is(err, ErrNotObtained) {
+		t.Fatalf("expected error to wrap ErrNotObtained, got %v", err)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected error to wrap context.DeadlineExceeded, got %v", err)
+	}
+}
+
 func TestObtain_concurrent(t *testing.T) {
 	lockKey := getLockKey()
 	ctx := context.Background()


### PR DESCRIPTION
Closes #79.

The README and example_test.go tell people to compare against \`ErrNotObtained\` after a deadline-bounded \`Obtain\`:

\`\`\`go
if err == redislock.ErrNotObtained { ... } else if err != nil { log.Fatalln(err) }
\`\`\`

That branch never fires when retry exhausts because the caller's context expired, because \`Obtain\` returns \`ctx.Err()\` bare. You fall into the generic error branch, which (per the example) \`log.Fatalln\`'s on what's really just \"someone else is still holding the lock.\"

Use \`errors.Join(ErrNotObtained, ctx.Err())\` so callers keep matching on \`errors.Is(err, ErrNotObtained)\` and still get the underlying context error for diagnostics.

Added a regression test that fails without the change.